### PR TITLE
Separate the localizable UI strings from the plugin name

### DIFF
--- a/inc/classes/class-settings.php
+++ b/inc/classes/class-settings.php
@@ -46,7 +46,7 @@ class Settings {
 		if ( current_user_can( 'manage_options' ) ) {
 			add_filter( 'plugin_action_links', [ $this, 'plugin_action_links' ], 10, 2 );
 		}
-		add_options_page( __( 'Log in with Google', 'login-with-google' ), __( 'Log in with Google', 'login-with-google' ), 'manage_options', 'login-with-google', [
+		add_options_page( _x( 'Log in with Google', 'Tab Title', 'login-with-google' ), _x( 'Log in with Google', 'Admin Menu', 'login-with-google' ), 'manage_options', 'login-with-google', [
 			$this,
 			'options_page'
 		] );

--- a/template/google-login-button.php
+++ b/template/google-login-button.php
@@ -7,7 +7,7 @@
  * @package login-with-google
  */
 
-$button_text = ( ! empty( $button_text ) ) ? $button_text : __( 'Log in with Google', 'login-with-google' );
+$button_text = ( ! empty( $button_text ) ) ? $button_text : _x( 'Log in with Google', 'Login Button', 'login-with-google' );
 
 if ( empty( $login_url ) ) {
 	return;


### PR DESCRIPTION
I don't translate the plugin name so keep it as English but some extra same and localizable UI strings can't be separated from the plugin name.

The modified codes can reach this purpose.