### PR TITLE
[Fix] Verify state on round trip

### DIFF
--- a/inc/classes/class-google-auth.php
+++ b/inc/classes/class-google-auth.php
@@ -116,7 +116,7 @@ class Google_Auth {
 		$redirect_to = ( ! wp_parse_url( $redirect_to, PHP_URL_HOST ) ) ? home_url( $redirect_to ) : $redirect_to;
 
 		$state = apply_filters(
-			'wp_google_client_state',
+			'login_with_google/client_state',
 			[
 				'redirect_to' => $redirect_to,
 				'blog_id'     => get_current_blog_id(),


### PR DESCRIPTION
## Summary

When using this plugin with [Login with github](https://github.com/rtCamp/login-with-github/) plugin, this one throws following fatal error.

```bash
[14-May-2021 12:01:57 UTC] PHP Fatal error:  Uncaught Error: Call to a member function fetchAccessTokenWithAuthCode() on null in /var/www/html/wp-content/plugins/login-with-google/inc/classes/class-google-auth.php:156
```

This is happening because Login with google is trying to handle the response returned from github, which it is not supposed to do.

## Solution

1. We will pass provider as `google` in state.

2. On round trip of the call (When we receive response from OAuth provider), we will verify whether the provider is set in state and if it is google. If yes, then only we are supposed to handle the response, else simply ignore it.

3. Ensure that passed state is exactly same as the received on in response. This will prevent call/attack from any third party. 