### PR TITLE
Fix: Redirect issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -50,14 +50,6 @@ Add your domain name, without any schema prefix and `www,` as the value of `WP_G
 
 = Hooks =
 
-Action `wp_google_login_token`
-This action provides access token received after Google login.
-**Parameters:**
-
-* `token` (Array): Converted token using `fetchAccessTokenWithAuthCode` method of `Google_Client` class.
-* `user_info` (Array): Details of user after login.
-* `client` (Object): `Google_Client` object in use.
-
 Filter `wp_google_login_scopes`
 This filter can be used to filter existing scope used in Google Sign in.
 You can ask for additional permission while user logs in.

--- a/src/Modules/Login.php
+++ b/src/Modules/Login.php
@@ -242,7 +242,7 @@ class Login implements ModuleInterface {
 	 */
 	public function state_redirect( array $state ): array {
 		$redirect_to          = Helper::filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_STRING );
-		$state['redirect_to'] = $redirect_to;
+		$state['redirect_to'] = $redirect_to ?? apply_filters( 'rtcamp.google_default_redirect', admin_url() );
 
 		return $state;
 	}

--- a/src/Modules/Login.php
+++ b/src/Modules/Login.php
@@ -242,6 +242,12 @@ class Login implements ModuleInterface {
 	 */
 	public function state_redirect( array $state ): array {
 		$redirect_to          = Helper::filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_STRING );
+		/**
+		 * Filter the default redirect URL in case redirect_to param is not available.
+		 * Default to admin URL.
+		 *
+		 * @param string $admin_url Admin URL address.
+		 */
 		$state['redirect_to'] = $redirect_to ?? apply_filters( 'rtcamp.google_default_redirect', admin_url() );
 
 		return $state;

--- a/tests/php/Unit/Modules/LoginTest.php
+++ b/tests/php/Unit/Modules/LoginTest.php
@@ -620,7 +620,7 @@ class LoginTest extends TestCase {
 	/**
 	 * @covers ::state_redirect
 	 */
-	public function testStateRedirect() {
+	public function testStateRedirectWithRedirectTo() {
 		$helperMock = Mockery::mock( 'alias:' . Helper::class );
 		$helperMock->expects( 'filter_input' )->once()->withArgs(
 			[
@@ -634,6 +634,32 @@ class LoginTest extends TestCase {
 
 		$this->assertIsArray( $state_data );
 		$this->assertContains( 'https://example.com/state-page', $state_data );
+	}
+
+	/**
+	 * @covers ::state_redirect
+	 */
+	public function testStateRedirectWithoutRedirectTo() {
+		$helperMock = Mockery::mock( 'alias:' . Helper::class );
+		$helperMock->expects( 'filter_input' )->once()->withArgs(
+			[
+				INPUT_GET,
+				'redirect_to',
+				FILTER_SANITIZE_STRING
+			]
+		)->andReturn( null );
+
+		$this->wpMockFunction(
+			'admin_url',
+			[],
+			1,
+			'https://example.com/login'
+		);
+
+		WP_Mock::expectFilter( 'rtcamp.google_default_redirect', 'https://example.com/login' );
+		$state_data = $this->testee->state_redirect( [] );
+		$this->assertIsArray( $state_data );
+		$this->assertContains( 'https://example.com/login', $state_data );
 	}
 
 	/**


### PR DESCRIPTION
1. When logging in via wp-login.php without redirect_to param, plugin is not logging-in users and forcing re-auth.

2. Remove redundant hook from readme.txt