### PR TITLE
Improve redability in readme for WP plugin page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,62 +13,84 @@ Minimal plugin that allows WordPress users to log in using Google.
 
 == Description ==
 
-Minimal plugin that allows WordPress users to log in using Google.
+Ultra minimal plugin to let your users login to WordPress applications using their Google accounts. No more remembering hefty passwords!
 
-= Setup =
+### Initial Setup
 
 1. Create a project from [Google Developers Console](https://console.developers.google.com/apis/dashboard) if none exists.
+
+
 2. Go to **Credentials** tab, then create credential for OAuth client.
     * Application type will be **Web Application**
     * Add `YOUR_DOMAIN/wp-login.php` in **Authorized redirect URIs**
+
+
 3. This will give you **Client ID** and **Secret key**.
+
+
 4. Input these values either in `WP Admin > Settings > WP Google Login`, or in `wp-config.php` using the following code snippet:
 
-`
+```
 define( 'WP_GOOGLE_LOGIN_CLIENT_ID', 'YOUR_GOOGLE_CLIENT_ID' );
 define( 'WP_GOOGLE_LOGIN_SECRET', 'YOUR_SECRET_KEY' );
-`
+````
 
-= How to enable automatic user registration =
+### How to enable automatic user registration
 
 You can enable user registration either by
-- Checking `Settings > WP Google Login > Enable Google Login Registration`
+- Enabling *Settings > WP Google Login > Enable Google Login Registration*
+
+
 OR
-- Adding `define( 'WP_GOOGLE_LOGIN_USER_REGISTRATION', 'true' );` in wp-config.php file.
 
-Note: If the checkbox is ON then, it will register valid Google users even when WordPress default setting, under `Settings > General Settings > Membership > Anyone can register` checkbox is OFF.
 
-= How to restrict user registration to one or more domain(s) =
+- Adding
+```
+define( 'WP_GOOGLE_LOGIN_USER_REGISTRATION', 'true' );
+```
+in wp-config.php file.
 
-By default, when you enable user registration via constant `WP_GOOGLE_LOGIN_USER_REGISTRATION` or enable `Settings > WP Google Login > Enable Google Login Registration`, it will create a user for any Google login (including gmail.com users). If you are planning to use this plugin on a private, internal site, then you may like to restrict user registration to users under a single Google Suite organization. This configuration variable does that.
+**Note:** If the checkbox is ON then, it will register valid Google users even when WordPress default setting, under
+
+*Settings > General Settings > Membership > Anyone can register* checkbox
+
+is OFF.
+
+### Restrict user registration to one or more domain(s)
+
+By default, when you enable user registration via constant `WP_GOOGLE_LOGIN_USER_REGISTRATION` or enable *Settings > WP Google Login > Enable Google Login Registration*, it will create a user for any Google login (including gmail.com users). If you are planning to use this plugin on a private, internal site, then you may like to restrict user registration to users under a single Google Suite organization. This configuration variable does that.
 
 Add your domain name, without any schema prefix and `www,` as the value of `WP_GOOGLE_LOGIN_WHITELIST_DOMAINS` constant or in the settings `Settings > WP Google Login > Whitelisted Domains`. You can whitelist multiple domains. Please separate domains with commas. See the below example to know how to do it via constants:
 
-`define( 'WP_GOOGLE_LOGIN_WHITELIST_DOMAINS', 'example.com,sample.com' );`
+```
+define( 'WP_GOOGLE_LOGIN_WHITELIST_DOMAINS', 'example.com,sample.com' );
+```
 
 **Note:** If a user already exists, they **will be allowed to login with Google** regardless of whether their domain is whitelisted or not. Whitelisting will only prevent users from **registering** with email addresses from non-whitelisted domains.
 
-= Hooks =
+### Hooks
 
 Filter `wp_google_login_scopes`
 This filter can be used to filter existing scope used in Google Sign in.
 You can ask for additional permission while user logs in.
 This filter will provide 1 parameter `scopes` in callback, which contains array of scopes.
 
-= wp-config.php parameters list =
+#### wp-config.php parameters list
 
 * `WP_GOOGLE_LOGIN_CLIENT_ID` (string): Google client ID of your application.
+
+
 * `WP_GOOGLE_LOGIN_SECRET` (string): Secret key of your application
+
+
 * `WP_GOOGLE_LOGIN_USER_REGISTRATION` (boolean) (optional): Set `true` If you want to enable new user registration. By default, user registration defers to `Settings > General Settings > Membership` if constant is not set.
+
+
 * `WP_GOOGLE_LOGIN_WHITELIST_DOMAINS` (string) (optional): Domain names, if you want to restrict login with your custom domain. By default, it will allow all domains. You can whitelist multiple domains.
 
-= Shortcode =
+### BTW, We're Hiring!
 
-The plugin makes available the `[google_login]` shortcode with optional attributes: `[google_login button_text="Login with Google" force_display="no" redirect_to="https://example.url/page"]`
-
-= BTW, We're Hiring! =
-
-[Join us at rtCamp, we specialize in providing high performance enterprise WordPress solutions](https://rtcamp.com/)
+[<img src="https://camo.githubusercontent.com/414c21a6d0e5f71c0e3b1da4380483b1240fdf36f85942c8e24b9f020236c8d9/68747470733a2f2f727463616d702e636f6d2f77702d636f6e74656e742f75706c6f6164732f323031392f30342f6769746875622d62616e6e65724032782e706e67" />](https://rtcamp.com/careers/)
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -126,13 +126,9 @@ Once you're ready to send a pull request, please run through the following check
 
 = Unit testing =
 
-- Setup local unit test environment by running script from terminal
+- Clone the plugin from [repository](https://github.com/rtCamp/login-with-google).
 
-`./bin/install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]`
-
-- Execute `phpunit` in terminal from repository to run all test cases.
-
-- Execute `phpunit ./tests/inc/test-class.php` in terminal with file path to run specific tests.
+- Run `composer install && composer tests:unit` to run unit tests.
 
 == Screenshots ==
 


### PR DESCRIPTION
Currently it is very difficult to gather information from the plugin page on WordPress.org 

Its lacking the formatting for code snippets and spaces are required in order for better separation and readability. 


For testing purpose, you can paste `Description` information here to live view the information: https://tools.wedevs.com/readme/