### PR TITLE
Save First and Last Name while Creating a user account

### DIFF
--- a/src/Utils/Authenticator.php
+++ b/src/Utils/Authenticator.php
@@ -95,6 +95,8 @@ class Authenticator {
 						'user_login' => Helper::unique_username( $user->login ),
 						'user_pass'  => wp_generate_password( 18 ),
 						'user_email' => $user->email,
+						'first_name' => $user->given_name,
+						'last_name'  => $user->family_name,
 					]
 				);
 

--- a/tests/php/Unit/Utils/AuthenticatorTest.php
+++ b/tests/php/Unit/Utils/AuthenticatorTest.php
@@ -186,8 +186,10 @@ class AuthenticatorTest extends TestCase {
 	 */
 	public function testRegisterReturnsUserObject() {
 		$user = (object) [
-			'email' => 'test@example.com',
-			'login' => 'test',
+			'email'       => 'test@example.com',
+			'login'       => 'test',
+			'given_name'  => 'Test',
+			'family_name' => 'User',
 		];
 
 		$this->settingsMock->registration_enabled = true;
@@ -213,6 +215,8 @@ class AuthenticatorTest extends TestCase {
 					'user_login' => 'test',
 					'user_pass'  => 'thisisrandompass',
 					'user_email' => 'test@example.com',
+					'first_name' => 'Test',
+					'last_name'  => 'User',
 				]
 			],
 			1,


### PR DESCRIPTION
Google account' first and last name will be saved to WP user account.

It will Fix [This Issue #101](https://github.com/rtCamp/login-with-google/issues/101)