### PR TITLE
GH-112 : Redirects back to login page after clicking login button

### DIFF
--- a/login-with-google.php
+++ b/login-with-google.php
@@ -112,6 +112,14 @@ function container(): Container {
 function plugin(): Plugin {
 	static $plugin;
 
+	$reauth = filter_input( INPUT_GET, 'reauth', FILTER_SANITIZE_STRING );
+	if ( null !== $reauth ) {
+		if ( ! empty( $_COOKIE[ LOGGED_IN_COOKIE ] ) ) {
+			wp_safe_redirect( wp_login_url() );
+			exit;
+		}
+	}
+
 	if ( null !== $plugin ) {
 		return $plugin;
 	}


### PR DESCRIPTION
## Description
**Issue**
- nonce verification failure when user visited `wp-login.php` with `reauth=1` query arg.  
- 
**cause**
- reauth=1 forces user for re-authentication even when `wordpressp_logged_in` cookie is set. Thus when nonce is  
generated for google-api query arguments `user_id` is present. While during nonce verification `user_id` is not present resulting in different nonce. Hence the failure.   

**Fix**
- Redirect to `wp-login.php` if the above scenario occurs before rendering the button. 

ref. 
- #112 