### PR TITLE
Resolve compatibility issue with PHP 8.1

### DIFF
--- a/src/Modules/Login.php
+++ b/src/Modules/Login.php
@@ -119,13 +119,13 @@ class Login implements ModuleInterface {
 			return $user;
 		}
 
-		$code = Helper::filter_input( INPUT_GET, 'code', FILTER_SANITIZE_STRING );
+		$code = Helper::filter_input( INPUT_GET, 'code', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( ! $code ) {
 			return $user;
 		}
 
-		$state         = Helper::filter_input( INPUT_GET, 'state', FILTER_SANITIZE_STRING );
+		$state         = Helper::filter_input( INPUT_GET, 'state', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$decoded_state = $state ? (array) ( json_decode( base64_decode( $state ) ) ) : null;
 
 		if ( ! is_array( $decoded_state ) || empty( $decoded_state['provider'] ) || 'google' !== $decoded_state['provider'] ) {
@@ -198,7 +198,7 @@ class Login implements ModuleInterface {
 	 * @return array
 	 */
 	public function state_redirect( array $state ): array {
-		$redirect_to = Helper::filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_STRING );
+		$redirect_to = Helper::filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		/**
 		 * Filter the default redirect URL in case redirect_to param is not available.
 		 * Default to admin URL.
@@ -216,7 +216,7 @@ class Login implements ModuleInterface {
 	 * @return void
 	 */
 	public function login_redirect(): void {
-		$state = Helper::filter_input( INPUT_GET, 'state', FILTER_SANITIZE_STRING );
+		$state = Helper::filter_input( INPUT_GET, 'state', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( ! $state || ! $this->authenticated ) {
 			return;

--- a/src/Modules/OneTapLogin.php
+++ b/src/Modules/OneTapLogin.php
@@ -162,7 +162,7 @@ class OneTapLogin implements Module {
 	 */
 	public function validate_token(): void {
 		try {
-			$token    = Helper::filter_input( INPUT_POST, 'token', FILTER_SANITIZE_STRING );
+			$token    = Helper::filter_input( INPUT_POST, 'token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			$verified = $this->token_verifier->verify_token( $token );
 
 			if ( ! $verified ) {
@@ -179,7 +179,7 @@ class OneTapLogin implements Module {
 			do_action( 'rtcamp.id_token_verified' );
 
 			$redirect_to   = apply_filters( 'rtcamp.google_default_redirect', admin_url() );
-			$state         = Helper::filter_input( INPUT_POST, 'state', FILTER_SANITIZE_STRING );
+			$state         = Helper::filter_input( INPUT_POST, 'state', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			$decoded_state = $state ? (array) ( json_decode( base64_decode( $state ) ) ) : null;
 
 			if ( is_array( $decoded_state ) && ! empty( $decoded_state['provider'] ) && 'google' === $decoded_state['provider'] ) {

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -87,7 +87,7 @@ class Helper {
 			 * Use the PHP method and bail out.
 			 */
 			switch ( $filter ) {
-				case FILTER_SANITIZE_STRING:
+				case FILTER_SANITIZE_FULL_SPECIAL_CHARS:
 					$sanitized_variable = filter_input( $type, $variable_name, $filter );
 					break;
 				default:

--- a/tests/php/Unit/Modules/LoginTest.php
+++ b/tests/php/Unit/Modules/LoginTest.php
@@ -146,7 +146,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'code',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( null );
 
@@ -168,7 +168,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'code',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( null );
 
@@ -194,7 +194,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'code',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( 'test_code' );
 
@@ -202,7 +202,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'state',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( $state );
 
@@ -224,7 +224,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'code',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( 'abc' );
 
@@ -232,7 +232,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'state',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( 'eyJwcm92aWRlciI6ImdpdGh1YiJ9' );
 
@@ -251,7 +251,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'code',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( 'abc' );
 
@@ -259,7 +259,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'state',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( 'eyJwcm92aWRlciI6Imdvb2dsZSIsIm5vbmNlIjoidGVzdG5vbmNlIn0=' );
 
@@ -310,7 +310,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'code',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( 'abc' );
 
@@ -318,7 +318,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'state',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( 'eyJwcm92aWRlciI6Imdvb2dsZSIsIm5vbmNlIjoidGVzdG5vbmNlIn0=' );
 
@@ -412,7 +412,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'redirect_to',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( 'https://example.com/state-page' );
 
@@ -431,7 +431,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'redirect_to',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( null );
 
@@ -457,7 +457,7 @@ class LoginTest extends TestCase {
 			[
 				INPUT_GET,
 				'state',
-				FILTER_SANITIZE_STRING
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
 			]
 		)->andReturn( [] );
 


### PR DESCRIPTION
## Description
- This PR resolves the compatibility issue with PHP 8.1
- The `FILTER_SANITIZE_STRING` is deprecated in PHP@8.1, so it is replaced with `FILTER_SANITIZE_FULL_SPECIAL_CHARS` which works same according to PHP docs.

### Related issue
- #104 

