### PR TITLE
Add WP version check workflow

### DIFF
--- a/.github/workflows/wordpress-version-checker.yml
+++ b/.github/workflows/wordpress-version-checker.yml
@@ -1,0 +1,23 @@
+name: "WordPress version checker"
+on:
+  push:
+    branches:
+      - develop
+      - trunk
+  pull_request:
+    branches:
+      - develop
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  issues: write
+
+jobs:
+  wordpress-version-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: WordPress version checker
+        uses: skaut/wordpress-version-checker@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.wordpress-version-checker.json
+++ b/.wordpress-version-checker.json
@@ -1,0 +1,4 @@
+{
+    "readme": "readme.txt",
+    "channel": "rc"
+}


### PR DESCRIPTION
## Description
Whenever a new version of WP is released, we are required to update the `Tested up to` information in the `readme.txt` file. This PR adds a workflow which is scheduled to run at `midnight on every Monday`. 

## Technical Details
1. Uses [skaut/wordpress-version-checker](https://github.com/skaut/wordpress-version-checker) GitHub action to check for the discrepancy between the latest WP version and the WP version in the readme.txt
2. The workflow is scheduled to run at `midnight on every Monday`. 

## Reference:
[https://github.com/10up/simple-local-avatars/blob/develop/.github/workflows/wordpress-version-checker.yml](https://github.com/10up/simple-local-avatars/blob/develop/.github/workflows/wordpress-version-checker.yml)

## Closes
