### PR TITLE
Workflow: Update the secret variables

### DIFF
--- a/.github/workflows/release_plugin_on_tag.yml
+++ b/.github/workflows/release_plugin_on_tag.yml
@@ -14,5 +14,5 @@ jobs:
         EXCLUDE_LIST: .github .gitignore .eslintignore phpunit.xml phpcs.xml tests README.md 
         SLUG: login-with-google
         ASSETS_DIR: wp-assets
-        WORDPRESS_PASSWORD: ${{ secrets.WORDPRESS_PASSWORD }}
-        WORDPRESS_USERNAME: ${{ secrets.WORDPRESS_USERNAME }}
+        WORDPRESS_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        WORDPRESS_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/release_plugin_on_tag.yml` file. The change updates the secrets used for WordPress credentials to use SVN credentials instead.

* [`.github/workflows/release_plugin_on_tag.yml`](diffhunk://#diff-c3e56a6daba55844ef7a6149c30b8be01627b836543e31e12ca6fce897cfa2d7L17-R18): Updated `WORDPRESS_PASSWORD` and `WORDPRESS_USERNAME` to use `secrets.SVN_PASSWORD` and `secrets.SVN_USERNAME` respectively.