### PR TITLE
Fix: Login issue - Need to click login with google button twice

### DIFF
--- a/login-with-google.php
+++ b/login-with-google.php
@@ -112,6 +112,14 @@ function container(): Container {
 function plugin(): Plugin {
 	static $plugin;
 
+	$reauth = filter_input( INPUT_GET, 'reauth', FILTER_SANITIZE_STRING );
+	if ( null !== $reauth ) {
+		if ( ! empty( $_COOKIE[ LOGGED_IN_COOKIE ] ) ) {
+			wp_safe_redirect( wp_login_url() );
+			exit;
+		}
+	}
+
 	if ( null !== $plugin ) {
 		return $plugin;
 	}


### PR DESCRIPTION
## Overview
•	This PR resolves the issue where users need to press the “Login with Google” button twice to log in to the site.
•	The issue occurs when the login cookie has expired.

## Fixes/Covers
- https://github.com/rtCamp/login-with-google/issues/112