### PR TITLE
Update publishing workflow

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,9 @@
+.github/
+.gitignore
+.eslintignore
+
+phpunit.xml
+phpcs.xml
+tests/
+README.md
+wp-assets/

--- a/.github/workflows/release_plugin_on_tag.yml
+++ b/.github/workflows/release_plugin_on_tag.yml
@@ -1,18 +1,50 @@
-name: Release Plugin
+name: Publish Plugin to WordPress.org
 on:
   push:
     tags:
       - '*'
+    branches:
+      - master
+      - develop
 jobs:
-  tag:
+  release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4.2.2
+    - name: Set up PHP
+      uses: shivammathur/setup-php@2.32.0
+      with:
+        php-version: '7.4'
+        coverage: xdebug
+        tools: composer,cs2pr
+    - name: Composer Install
+      shell: bash
+      run: |
+        composer install --no-dev --prefer-dist --no-progress --no-suggest
     - name: WordPress Plugin Deploy
-      uses: rtCamp/action-wordpress-org-plugin-deploy@master
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@2.3.0
+      with:
+        generate-zip: 'true'
+        dry-run: ${{ startsWith(github.ref, 'refs/tags/v') != true }}
       env:
-        EXCLUDE_LIST: .github .gitignore .eslintignore phpunit.xml phpcs.xml tests README.md 
-        SLUG: login-with-google
-        ASSETS_DIR: wp-assets
-        WORDPRESS_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        WORDPRESS_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: 'login-with-google'
+        ASSETS_DIR: 'wp-assets'
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        VERSION: '${{ github.ref_name }}'
+    - name: Upload Test Artifact
+      if: startsWith(github.ref, 'refs/tags/v') != true
+      uses: actions/upload-artifact@v4.6.1
+      with:
+        name: plugin
+        path: '${{ steps.deploy.outputs.zip-path }}'
+    - name: Upload Release Artifact
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v2.2.1
+      with:
+        files: |
+          ${{ steps.deploy.outputs.zip-path }}
+        token: '${{ github.token }}'
+        tag_name: ${{ github.ref_name }}
+        draft: true

--- a/.github/workflows/release_plugin_on_tag.yml
+++ b/.github/workflows/release_plugin_on_tag.yml
@@ -3,9 +3,6 @@ on:
   push:
     tags:
       - '*'
-    branches:
-      - master
-      - develop
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -26,7 +23,7 @@ jobs:
       uses: 10up/action-wordpress-plugin-deploy@2.3.0
       with:
         generate-zip: 'true'
-        dry-run: ${{ startsWith(github.ref, 'refs/tags/v') != true }}
+        dry-run: ${{ startsWith(github.ref, 'refs/tags/dry') }}
       env:
         SLUG: 'login-with-google'
         ASSETS_DIR: 'wp-assets'
@@ -34,13 +31,13 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         VERSION: '${{ github.ref_name }}'
     - name: Upload Test Artifact
-      if: startsWith(github.ref, 'refs/tags/v') != true
+      if: startsWith(github.ref, 'refs/tags/dry')
       uses: actions/upload-artifact@v4.6.1
       with:
         name: plugin
         path: '${{ steps.deploy.outputs.zip-path }}'
     - name: Upload Release Artifact
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.ref, 'refs/tags/dry') == false
       uses: softprops/action-gh-release@v2.2.1
       with:
         files: |


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow for releasing a WordPress plugin. The changes enhance the workflow by renaming the job, adding branch triggers, updating dependencies, and improving artifact handling.

Enhancements to the release workflow:

* [`.github/workflows/release_plugin_on_tag.yml`](diffhunk://#diff-c3e56a6daba55844ef7a6149c30b8be01627b836543e31e12ca6fce897cfa2d7L1-R50): Renamed the job from "Release Plugin" to "Publish Plugin to WordPress.org" and added branch triggers for `master` and `develop`.
* [`.github/workflows/release_plugin_on_tag.yml`](diffhunk://#diff-c3e56a6daba55844ef7a6149c30b8be01627b836543e31e12ca6fce897cfa2d7L1-R50): Updated the `actions/checkout` version to `v4.2.2` and added a step to set up PHP with version `7.4`, including necessary tools like composer and cs2pr.
* [`.github/workflows/release_plugin_on_tag.yml`](diffhunk://#diff-c3e56a6daba55844ef7a6149c30b8be01627b836543e31e12ca6fce897cfa2d7L1-R50): Changed the WordPress Plugin Deploy action to use `10up/action-wordpress-plugin-deploy@2.3.0` and included a `dry-run` option based on tag conditions.
* [`.github/workflows/release_plugin_on_tag.yml`](diffhunk://#diff-c3e56a6daba55844ef7a6149c30b8be01627b836543e31e12ca6fce897cfa2d7L1-R50): Added steps to upload test artifacts if the push is not a tag and to upload release artifacts if the push is a tag, using `actions/upload-artifact@v4.6.1` and `softprops/action-gh-release@v2.2.1` respectively.