### PR TITLE
fix: exclude `assets/build/*` from phpcs

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -60,5 +60,5 @@
     <exclude-pattern>*/tests/*</exclude-pattern>
     <exclude-pattern>*/.github/*</exclude-pattern>
     <exclude-pattern>*/.scripts/*</exclude-pattern>
-    <exclude-pattern>./assets/build</exclude-pattern>
+    <exclude-pattern>./assets/build/*</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -60,5 +60,5 @@
     <exclude-pattern>*/tests/*</exclude-pattern>
     <exclude-pattern>*/.github/*</exclude-pattern>
     <exclude-pattern>*/.scripts/*</exclude-pattern>
-    <exclude-pattern>./assets/build/*</exclude-pattern>
+    <exclude-pattern>*/assets/build/*</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -60,5 +60,5 @@
     <exclude-pattern>*/tests/*</exclude-pattern>
     <exclude-pattern>*/.github/*</exclude-pattern>
     <exclude-pattern>*/.scripts/*</exclude-pattern>
-    <exclude-pattern>*/assets/build/*</exclude-pattern>
+    <exclude-pattern>assets/build/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Overview 
- This will exclude `./assets/build/*` from PHPCS inspection 