### PR TITLE
Migration of One tap to FedCM

### DIFF
--- a/src/Modules/OneTapLogin.php
+++ b/src/Modules/OneTapLogin.php
@@ -110,7 +110,7 @@ class OneTapLogin implements Module {
 	 */
 	public function one_tap_prompt(): void {
 		?>
-		<div id="g_id_onload" data-client_id="<?php echo esc_attr( $this->settings->client_id ); ?>" data-login_uri="<?php echo esc_attr( wp_login_url() ); ?>" data-callback="LoginWithGoogleDataCallBack"></div>
+		<div id="g_id_onload" data-use_fedcm_for_prompt="true" data-client_id="<?php echo esc_attr( $this->settings->client_id ); ?>" data-login_uri="<?php echo esc_attr( wp_login_url() ); ?>" data-callback="LoginWithGoogleDataCallBack"></div>
 		<?php
 	}
 


### PR DESCRIPTION
## Description
This PR will migrate the one-tap login functionality to FedCM.
## Technical Implementation
Added `data-use_fedcm_for_prompt="true"` attribute to the one-tap prompt markup.
## Fixes/Covers
- https://github.com/rtCamp/login-with-google/issues/179

Note: This PR is the copy of previous work done by @mchirag2002 in this PR - https://github.com/rtCamp/login-with-google/pull/182. I have migrated the previous work after the hard reset on branch