### PR TITLE
Fix: Add dynamic redirection URL to block and One-tap login

### DIFF
--- a/src/Modules/Block.php
+++ b/src/Modules/Block.php
@@ -164,9 +164,9 @@ class Block implements Module {
 		$force_display = $attributes['forceDisplay'] ?? false;
 
 		// Setting up dynamic redirect URL based on the current page.
-		$redirects_to       = $this->set_redirect_url();
+		$redirects_to       = $this->get_redirect_url();
 		$this->redirect_url = $redirects_to;
-		add_filter( 'rtcamp.google_login_state', [ $this, 'state_redirect' ] );
+		add_filter( 'rtcamp.google_login_state', [ $this, 'set_state_redirect' ] );
 
 		if ( $force_display || ! is_user_logged_in() || apply_filters( 'rtcamp.google_login_button_display', false ) ) {
 			$markup = $this->markup(
@@ -187,7 +187,7 @@ class Block implements Module {
 			return ob_get_clean();
 		}
 
-		remove_filter( 'rtcamp.google_login_state', [ $this, 'state_redirect' ] );
+		remove_filter( 'rtcamp.google_login_state', [ $this, 'set_state_redirect' ] );
 
 		return '';
 	}
@@ -214,11 +214,11 @@ class Block implements Module {
 	}
 
 	/**
-	 * Set the redirection URL.
+	 * Get the redirection URL.
 	 *
 	 * @return string
 	 */
-	public function set_redirect_url(): string {
+	public function get_redirect_url(): string {
 		global $pagenow;
 
 		$redirect_to = '';
@@ -248,7 +248,7 @@ class Block implements Module {
 	 * 
 	 * @return array
 	 */	
-	public function state_redirect( array $state ): array {
+	public function set_state_redirect( array $state ): array {
 		if ( is_null( $this->redirect_url ) ) {
 			return $state;
 		}

--- a/src/Modules/Block.php
+++ b/src/Modules/Block.php
@@ -224,7 +224,7 @@ class Block implements Module {
 		$redirect_to = '';
 
 		if ( 'wp-login.php' === $pagenow ) {
-			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_DEFAULT );
+			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_VALIDATE_URL );
 			
 			// In case no query parameter is available.
 			if ( is_null( $redirect_to ) ) {
@@ -247,7 +247,7 @@ class Block implements Module {
 	 * @param array $state Contains the state array.
 	 * 
 	 * @return array
-	 */	
+	 */
 	public function set_state_redirect( array $state ): array {
 		if ( is_null( $this->redirect_url ) ) {
 			return $state;

--- a/src/Modules/Block.php
+++ b/src/Modules/Block.php
@@ -164,9 +164,9 @@ class Block implements Module {
 		$force_display = $attributes['forceDisplay'] ?? false;
 
 		// Setting up dynamic redirect URL based on the current page.
-		$redirects_to       = $this->get_redirect_url();
-		$this->redirect_url = $redirects_to;
-		add_filter( 'rtcamp.google_login_state', [ $this, 'set_state_redirect' ] );
+		$redirects_to = Helper::get_redirect_url();
+
+		Helper::set_state_redirect( $redirects_to );
 
 		if ( $force_display || ! is_user_logged_in() || apply_filters( 'rtcamp.google_login_button_display', false ) ) {
 			$markup = $this->markup(
@@ -187,7 +187,7 @@ class Block implements Module {
 			return ob_get_clean();
 		}
 
-		remove_filter( 'rtcamp.google_login_state', [ $this, 'set_state_redirect' ] );
+		Helper::remove_state_redirect();
 
 		return '';
 	}
@@ -211,50 +211,5 @@ class Block implements Module {
 
 		$template = trailingslashit( plugin()->template_dir ) . 'google-login-button.php';
 		return Helper::render_template( $template, $args, false );
-	}
-
-	/**
-	 * Get the redirection URL.
-	 *
-	 * @return string
-	 */
-	public function get_redirect_url(): string {
-		global $pagenow;
-
-		$redirect_to = '';
-
-		if ( 'wp-login.php' === $pagenow ) {
-			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_VALIDATE_URL );
-			
-			// In case no query parameter is available.
-			if ( is_null( $redirect_to ) ) {
-				$redirect_to = '';
-			}
-		} else {
-			$redirect_to = get_permalink();
-		}
-
-		if ( '' === $redirect_to ) {
-			$redirect_to = apply_filters( 'rtcamp.google_default_redirect', admin_url() );
-		}
-
-		return $redirect_to;
-	}
-
-	/**
-	 * Updating the state variable to set the dynamic url.
-	 * 
-	 * @param array $state Contains the state array.
-	 * 
-	 * @return array
-	 */
-	public function set_state_redirect( array $state ): array {
-		if ( is_null( $this->redirect_url ) ) {
-			return $state;
-		}
-
-		$state['redirect_to'] = $this->redirect_url;
-
-		return $state;
 	}
 }

--- a/src/Modules/Block.php
+++ b/src/Modules/Block.php
@@ -49,13 +49,6 @@ class Block implements Module {
 	public $client;
 
 	/**
-	 * URL to be redirected to post successful login.
-	 * 
-	 * @var string
-	 */
-	private $redirect_url = '';
-
-	/**
 	 * Module name.
 	 *
 	 * @return string
@@ -166,7 +159,7 @@ class Block implements Module {
 		// Setting up dynamic redirect URL based on the current page.
 		$redirects_to = Helper::get_redirect_url();
 
-		Helper::set_state_redirect( $redirects_to );
+		Helper::set_redirect_state_filter( $redirects_to );
 
 		if ( $force_display || ! is_user_logged_in() || apply_filters( 'rtcamp.google_login_button_display', false ) ) {
 			$markup = $this->markup(
@@ -187,7 +180,7 @@ class Block implements Module {
 			return ob_get_clean();
 		}
 
-		Helper::remove_state_redirect();
+		Helper::remove_redirect_state_filter();
 
 		return '';
 	}

--- a/src/Modules/OneTapLogin.php
+++ b/src/Modules/OneTapLogin.php
@@ -127,11 +127,10 @@ class OneTapLogin implements Module {
 	 * @return void
 	 */
 	public function one_tap_scripts(): void {
-		$filename           = ( defined( 'WP_SCRIPT_DEBUG' ) && true === WP_SCRIPT_DEBUG ) ? 'onetap.min.js' : 'onetap.js';
-		$redirects_to       = $this->get_redirect_url();
-		$this->redirect_url = $redirects_to;
-		
-		add_filter( 'rtcamp.google_login_state', [ $this, 'set_state_redirect' ] );
+		$filename     = ( defined( 'WP_SCRIPT_DEBUG' ) && true === WP_SCRIPT_DEBUG ) ? 'onetap.min.js' : 'onetap.js';
+		$redirects_to = Helper::get_redirect_url();
+
+		Helper::set_state_redirect( $redirects_to );
 
 		wp_enqueue_script(
 			'login-with-google-one-tap',
@@ -147,7 +146,7 @@ class OneTapLogin implements Module {
 			'homeurl' => get_option( 'home', '' ),
 		];
 
-		remove_filter( 'rtcamp.google_login_state', [ $this, 'set_state_redirect' ] );
+		Helper::remove_state_redirect();
 
 		wp_register_script(
 			'login-with-google-one-tap-js',
@@ -227,50 +226,5 @@ class OneTapLogin implements Module {
 
 		$wp_user = $this->authenticator->authenticate( $user );
 		$this->authenticator->set_auth_cookies( $wp_user );
-	}
-
-	/**
-	 * Get the redirection URL.
-	 *
-	 * @return string
-	 */
-	public function get_redirect_url(): string {
-		global $pagenow;
-
-		$redirect_to = '';
-
-		if ( 'wp-login.php' === $pagenow ) {
-			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_VALIDATE_URL );
-			
-			// In case no query parameter is available.
-			if ( is_null( $redirect_to ) ) {
-				$redirect_to = '';
-			}
-		} else {
-			$redirect_to = get_permalink();
-		}
-
-		if ( '' === $redirect_to ) {
-			$redirect_to = apply_filters( 'rtcamp.google_default_redirect', admin_url() );
-		}
-
-		return $redirect_to;
-	}
-
-	/**
-	 * Updating the state variable to set the dynamic url.
-	 * 
-	 * @param array $state Contains the state array.
-	 * 
-	 * @return array
-	 */
-	public function set_state_redirect( array $state ): array {
-		if ( is_null( $this->redirect_url ) ) {
-			return $state;
-		}
-
-		$state['redirect_to'] = $this->redirect_url;
-
-		return $state;
 	}
 }

--- a/src/Modules/OneTapLogin.php
+++ b/src/Modules/OneTapLogin.php
@@ -240,7 +240,7 @@ class OneTapLogin implements Module {
 		$redirect_to = '';
 
 		if ( 'wp-login.php' === $pagenow ) {
-			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_DEFAULT );
+			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_VALIDATE_URL );
 			
 			// In case no query parameter is available.
 			if ( is_null( $redirect_to ) ) {
@@ -263,7 +263,7 @@ class OneTapLogin implements Module {
 	 * @param array $state Contains the state array.
 	 * 
 	 * @return array
-	 */	
+	 */
 	public function set_state_redirect( array $state ): array {
 		if ( is_null( $this->redirect_url ) ) {
 			return $state;

--- a/src/Modules/OneTapLogin.php
+++ b/src/Modules/OneTapLogin.php
@@ -56,13 +56,6 @@ class OneTapLogin implements Module {
 	private $authenticator;
 
 	/**
-	 * URL to be redirected to post successful login.
-	 * 
-	 * @var string
-	 */
-	private $redirect_url = '';
-
-	/**
 	 * OneTapLogin constructor.
 	 *
 	 * @param Settings      $settings Settings object.
@@ -130,7 +123,7 @@ class OneTapLogin implements Module {
 		$filename     = ( defined( 'WP_SCRIPT_DEBUG' ) && true === WP_SCRIPT_DEBUG ) ? 'onetap.min.js' : 'onetap.js';
 		$redirects_to = Helper::get_redirect_url();
 
-		Helper::set_state_redirect( $redirects_to );
+		Helper::set_redirect_state_filter( $redirects_to );
 
 		wp_enqueue_script(
 			'login-with-google-one-tap',
@@ -146,7 +139,7 @@ class OneTapLogin implements Module {
 			'homeurl' => get_option( 'home', '' ),
 		];
 
-		Helper::remove_state_redirect();
+		Helper::remove_redirect_state_filter();
 
 		wp_register_script(
 			'login-with-google-one-tap-js',

--- a/src/Modules/OneTapLogin.php
+++ b/src/Modules/OneTapLogin.php
@@ -128,10 +128,10 @@ class OneTapLogin implements Module {
 	 */
 	public function one_tap_scripts(): void {
 		$filename           = ( defined( 'WP_SCRIPT_DEBUG' ) && true === WP_SCRIPT_DEBUG ) ? 'onetap.min.js' : 'onetap.js';
-		$redirects_to       = $this->set_redirect_url();
+		$redirects_to       = $this->get_redirect_url();
 		$this->redirect_url = $redirects_to;
 		
-		add_filter( 'rtcamp.google_login_state', [ $this, 'state_redirect' ] );
+		add_filter( 'rtcamp.google_login_state', [ $this, 'set_state_redirect' ] );
 
 		wp_enqueue_script(
 			'login-with-google-one-tap',
@@ -147,7 +147,7 @@ class OneTapLogin implements Module {
 			'homeurl' => get_option( 'home', '' ),
 		];
 
-		remove_filter( 'rtcamp.google_login_state', [ $this, 'state_redirect' ] );
+		remove_filter( 'rtcamp.google_login_state', [ $this, 'set_state_redirect' ] );
 
 		wp_register_script(
 			'login-with-google-one-tap-js',
@@ -230,11 +230,11 @@ class OneTapLogin implements Module {
 	}
 
 	/**
-	 * Set the redirection URL.
+	 * Get the redirection URL.
 	 *
 	 * @return string
 	 */
-	public function set_redirect_url(): string {
+	public function get_redirect_url(): string {
 		global $pagenow;
 
 		$redirect_to = '';
@@ -264,7 +264,7 @@ class OneTapLogin implements Module {
 	 * 
 	 * @return array
 	 */	
-	public function state_redirect( array $state ): array {
+	public function set_state_redirect( array $state ): array {
 		if ( is_null( $this->redirect_url ) ) {
 			return $state;
 		}

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -200,31 +200,37 @@ class Helper {
 	}
 
 	/**
-	 * Get the redirection URL.
+	 * Get the redirection URL and set the redirection URL to the default URL.
+	 * 
+	 * This function offers customization to the users for the URL that they want to be redirected to.
+	 * The filter `rtcamp.google_default_redirect` can be used to manipulate the value of $default_redirect_url.
+	 * This way the updated redirection URL customized by the user can be integrated into current system.
 	 *
 	 * @return string
 	 */
 	public static function get_redirect_url(): string {
 		global $pagenow;
 
-		$redirect_to = '';
+		// Initializing the deafult with admin URL.
+		$default_redirect_url = admin_url();
 
 		if ( 'wp-login.php' === $pagenow ) {
+			// If any redirect_to query parameter is available.
 			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_VALIDATE_URL );
 			
-			// In case no query parameter is available.
-			if ( is_null( $redirect_to ) ) {
-				$redirect_to = '';
+			// In case query parameter is available.
+			if ( ! is_null( $redirect_to ) ) {
+				$default_redirect_url = $redirect_to;
 			}
+
 		} else {
-			$redirect_to = get_permalink();
+			$default_redirect_url = get_permalink();
 		}
 
-		if ( '' === $redirect_to ) {
-			$redirect_to = apply_filters( 'rtcamp.google_default_redirect', admin_url() );
-		}
+		// If any manipulation needs to be done.
+		$default_redirect_url = apply_filters( 'rtcamp.google_default_redirect', $default_redirect_url );
 
-		return $redirect_to;
+		return $default_redirect_url;
 	}
 
 	/**

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -223,7 +223,10 @@ class Helper {
 				$default_redirect_url = $redirect_to;
 			}
 		} else {
-			$default_redirect_url = get_permalink();
+			$home_url             = home_url();
+			$uri_from_server      = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_DEFAULT );
+			$final_request_uri    = ( is_string( $uri_from_server ) && '' !== $uri_from_server ) ? trim( $uri_from_server ) : '/';
+			$default_redirect_url = $home_url . $final_request_uri;
 		}
 
 		// If any manipulation needs to be done.

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -224,7 +224,7 @@ class Helper {
 			}
 		} else {
 			$home_url             = home_url();
-			$uri_from_server      = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_DEFAULT );
+			$uri_from_server      = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_VALIDATE_URL );
 			$final_request_uri    = ( is_string( $uri_from_server ) && '' !== $uri_from_server ) ? trim( $uri_from_server ) : '/';
 			$default_redirect_url = $home_url . $final_request_uri;
 		}

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -222,7 +222,6 @@ class Helper {
 			if ( ! is_null( $redirect_to ) ) {
 				$default_redirect_url = $redirect_to;
 			}
-
 		} else {
 			$default_redirect_url = get_permalink();
 		}

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -17,6 +17,11 @@ namespace RtCamp\GoogleLogin\Utils;
  */
 class Helper {
 
+	/**
+	 * URL to be redirected to post successful login.
+	 * 
+	 * @var string
+	 */
 	public static $redirection_url = '';
 
 	/**
@@ -229,14 +234,14 @@ class Helper {
 	 * 
 	 * @return void
 	 */
-	public static function set_state_redirect( $redirect_to ) {
+	public static function set_redirect_state_filter( $redirect_to ) {
 		if ( empty( $redirect_to ) ) {
 			return;
 		}
 
 		self::$redirection_url = $redirect_to;
 
-		add_filter( 'rtcamp.google_login_state', [ __CLASS__, 'update_state_redirect' ] );
+		add_filter( 'rtcamp.google_login_state', [ __CLASS__, 'update_redirect_state' ] );
 	}
 
 	/**
@@ -246,7 +251,7 @@ class Helper {
 	 * 
 	 * @return array
 	 */
-	public static function update_state_redirect( array $state ): array {
+	public static function update_redirect_state( array $state ): array {
 		if ( is_null( self::$redirection_url ) ) {
 			return $state;
 		}
@@ -261,7 +266,7 @@ class Helper {
 	 * 
 	 * @return void
 	 */
-	public static function remove_state_redirect() {
-		remove_filter( 'rtcamp.google_login_state', [ __CLASS__, 'update_state_redirect' ] );
+	public static function remove_redirect_state_filter() {
+		remove_filter( 'rtcamp.google_login_state', [ __CLASS__, 'update_redirect_state' ] );
 	}
 }

--- a/templates/google-login-button.php
+++ b/templates/google-login-button.php
@@ -21,7 +21,7 @@ $button_url = $login_url;
 if ( is_user_logged_in() ) {
 	$button_text       = __( 'Log out', 'login-with-google' );
 	$home_url          = home_url();
-	$uri_from_server   = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_DEFAULT );
+	$uri_from_server   = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_VALIDATE_URL );
 	$final_request_uri = ( is_string( $uri_from_server ) && '' !== $uri_from_server ) ? trim( $uri_from_server ) : '/';
 	$redirect_url      = $home_url . $final_request_uri;
 	$button_url        = wp_logout_url( $redirect_url );

--- a/templates/google-login-button.php
+++ b/templates/google-login-button.php
@@ -6,6 +6,8 @@
  * @since 1.0.0
  */
 
+ use RtCamp\GoogleLogin\Utils\Helper;
+
 if ( isset( $custom_btn_text ) && $custom_btn_text ) {
 	$button_text = esc_html( $custom_btn_text );
 } else {
@@ -20,10 +22,11 @@ $button_url = $login_url;
 
 if ( is_user_logged_in() ) {
 	$button_text       = __( 'Log out', 'login-with-google' );
-	$home_url          = home_url();
-	$uri_from_server   = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_VALIDATE_URL );
-	$final_request_uri = ( is_string( $uri_from_server ) && '' !== $uri_from_server ) ? trim( $uri_from_server ) : '/';
-	$redirect_url      = $home_url . $final_request_uri;
+	// $home_url          = home_url();
+	// $uri_from_server   = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_VALIDATE_URL );
+	// $final_request_uri = ( is_string( $uri_from_server ) && '' !== $uri_from_server ) ? trim( $uri_from_server ) : '/';
+	// $redirect_url      = $home_url . $final_request_uri;
+	$redirect_url = Helper::get_redirect_url();
 	$button_url        = wp_logout_url( $redirect_url );
 }
 ?>

--- a/templates/google-login-button.php
+++ b/templates/google-login-button.php
@@ -19,8 +19,12 @@ if ( empty( $login_url ) ) {
 $button_url = $login_url;
 
 if ( is_user_logged_in() ) {
-	$button_text = __( 'Log out', 'login-with-google' );
-	$button_url  = wp_logout_url( get_permalink() );
+	$button_text       = __( 'Log out', 'login-with-google' );
+	$home_url          = home_url();
+	$uri_from_server   = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_DEFAULT );
+	$final_request_uri = ( is_string( $uri_from_server ) && '' !== $uri_from_server ) ? trim( $uri_from_server ) : '/';
+	$redirect_url      = $home_url . $final_request_uri;
+	$button_url        = wp_logout_url( $redirect_url );
 }
 ?>
 <div class="wp_google_login">

--- a/templates/google-login-button.php
+++ b/templates/google-login-button.php
@@ -21,9 +21,9 @@ if ( empty( $login_url ) ) {
 $button_url = $login_url;
 
 if ( is_user_logged_in() ) {
-	$button_text       = __( 'Log out', 'login-with-google' );
+	$button_text  = __( 'Log out', 'login-with-google' );
 	$redirect_url = Helper::get_redirect_url();
-	$button_url        = wp_logout_url( $redirect_url );
+	$button_url   = wp_logout_url( $redirect_url );
 }
 ?>
 <div class="wp_google_login">

--- a/templates/google-login-button.php
+++ b/templates/google-login-button.php
@@ -6,7 +6,7 @@
  * @since 1.0.0
  */
 
- use RtCamp\GoogleLogin\Utils\Helper;
+use RtCamp\GoogleLogin\Utils\Helper;
 
 if ( isset( $custom_btn_text ) && $custom_btn_text ) {
 	$button_text = esc_html( $custom_btn_text );
@@ -22,10 +22,6 @@ $button_url = $login_url;
 
 if ( is_user_logged_in() ) {
 	$button_text       = __( 'Log out', 'login-with-google' );
-	// $home_url          = home_url();
-	// $uri_from_server   = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_VALIDATE_URL );
-	// $final_request_uri = ( is_string( $uri_from_server ) && '' !== $uri_from_server ) ? trim( $uri_from_server ) : '/';
-	// $redirect_url      = $home_url . $final_request_uri;
 	$redirect_url = Helper::get_redirect_url();
 	$button_url        = wp_logout_url( $redirect_url );
 }


### PR DESCRIPTION
# Description
- In the current version, the following login methods were already redirecting to the source page:
   - `LWG Shortcode`
   - `Core login/out block`

- This PR adds this feature to the following login methods as well:
   - `LWG login block`
   - `One-tap login`

# Technical Implementation
- Created a modular function in `Helper` class to fetch the redirection URL and added overwriting functionality by integrating the `rtcamp.google_default_redirect` filter.
- Created two functions in `Helper` class to add and remove the `rtcamp.google_login_state` filter to modify the state variable.
- Modified the shortcode login logic to use the same new logic.

# Fixes 
- https://wordpress.org/support/topic/redirect-to-original-page-2/
- https://github.com/rtCamp/login-with-google/issues/232
