### PR TITLE
enhance: populate x-redirect-by with Login With Google while redirecting

### DIFF
--- a/login-with-google.php
+++ b/login-with-google.php
@@ -117,7 +117,7 @@ function plugin(): Plugin {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verification is not required here.
 	if ( isset( $_GET['reauth'] ) && null !== sanitize_text_field( wp_unslash( $_GET['reauth'] ) ) ) {
 		if ( ! empty( $_COOKIE[ LOGGED_IN_COOKIE ] ) ) {
-			wp_safe_redirect( wp_login_url() );
+			wp_safe_redirect( wp_login_url(), 302, 'Login with Google' );
 			exit;
 		}
 	}

--- a/src/Modules/Login.php
+++ b/src/Modules/Login.php
@@ -226,7 +226,7 @@ class Login implements ModuleInterface {
 		$state = $state ? json_decode( $state ) : null;
 
 		if ( ( $state instanceof stdClass ) && ! empty( $state->provider ) && 'google' === $state->provider && ! empty( $state->redirect_to ) ) {
-			wp_safe_redirect( $state->redirect_to );
+			wp_safe_redirect( $state->redirect_to, 302, 'Login with Google' );
 			exit;
 		}
 	}


### PR DESCRIPTION
## Description
Currently, when using `wp_safe_redirect()`, we leave the third parameter, `x_redirect_by`, unset. However, this parameter is quite helpful for debugging purposes, as it indicates which plugin or source initiated the redirect. [Safe Redirect Manager](https://github.com/10up/safe-redirect-manager) plugin also uses this 

https://github.com/10up/safe-redirect-manager/blob/5b824ed54c5748bebe31a58d5af02ad1c154927b/inc/classes/class-srm-redirect.php#L359-L360

References: 
https://developer.wordpress.org/reference/functions/wp_safe_redirect/

