### PR TITLE
Fix: Ensure unique username generation works correctly using incremen…

### DIFF
--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -181,11 +181,11 @@ class Helper {
 	 *
 	 * @return string
 	 */
-	public static function unique_username(string $username): string {
+	public static function unique_username( string $username ): string {
 		$uname = $username;
 		$count = 1;
 
-		while (username_exists($uname)) {
+		while ( username_exists( $uname ) ) {
 			$uname = $username . $count;
 			++$count;
 		}

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -186,7 +186,8 @@ class Helper {
 		$count = 1;
 
 		while ( username_exists( $uname ) ) {
-			$uname = $uname . '' . $count;
+			$uname = $uname . '' . $count; // Fix: Reset the username to original and append the count.
+            $count++;
 		}
 
 		return $uname;

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -181,15 +181,15 @@ class Helper {
 	 *
 	 * @return string
 	 */
-    public static function unique_username( string $username ): string {
-        $uname = $username;
-        $count = 1;
-    
-        while ( username_exists( $uname ) ) {
-            $uname = $username . $count;
-            ++$count;
-        }
-    
-        return $uname;
-    }
+	public static function unique_username(string $username): string {
+		$uname = $username;
+		$count = 1;
+
+		while (username_exists($uname)) {
+			$uname = $username . $count;
+			++$count;
+		}
+
+		return $uname;
+	}
 }

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -181,15 +181,15 @@ class Helper {
 	 *
 	 * @return string
 	 */
-	public static function unique_username( string $username ): string {
-		$uname = $username;
-		$count = 1;
-
-		while ( username_exists( $uname ) ) {
-			$uname = $uname . '' . $count; // Fix: Reset the username to original and append the count.
-            $count++;
-		}
-
-		return $uname;
-	}
+    public static function unique_username( string $username ): string {
+        $uname = $username;
+        $count = 1;
+    
+        while ( username_exists( $uname ) ) {
+            $uname = $username . $count;
+            ++$count;
+        }
+    
+        return $uname;
+    }
 }


### PR DESCRIPTION
**Fix: Bug in `Helper::unique_username()` method**

**Description:** 

This fix addresses a bug where generated usernames kept stacking numbers without resetting the base username. For example, instead of `john`, `john1`, `john2`, it was generating `john`, `john1`, `john11`, `john111`, and so on. This could lead to infinite loops or invalid usernames.

**Bug Explanation:**  
In the existing code, the username was updated like this:  
`$uname = $uname . $count;`  
This caused the username to grow on every iteration.

**Fix:**  
The corrected code resets the base username during each loop iteration:  
`$uname = $username . $count;`  
Now, usernames are generated properly as `john1`, `john2`, `john3`, etc., ensuring uniqueness without infinite stacking.

**Notes:**  
Let me know if tests or additional changes are needed.