### PR TITLE
Added code snippet to assign different user role to the user created by the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 > WordPress plugin to login/register with Google
 
-- [Overview](#overview)
-- [Installation](#installation)
-- [Browser support](#browser-support)
-- [Usage Instructions](#usage-instructions)
-- [Plugin Constants](#plugin-constants)
-- [Hooks](#hooks)
-    - [Filters](#filters)
-    - [Actions](#actions)
-- [Shortcode](#shortcode)
-- [Contribute](#contribute)
-- [Unit testing](#unit-testing)
-- [Minimum Requirements](#minimum-requirements)
-- [License](#license)
-- [BTW, We're Hiring!](#btw-were-hiring)
+- [Login with Google](#login-with-google)
+  - [Overview](#overview)
+  - [Installation](#installation)
+  - [Browser support](#browser-support)
+  - [Usage Instructions](#usage-instructions)
+    - [Plugin Constants](#plugin-constants)
+    - [Hooks](#hooks)
+      - [Filters](#filters)
+      - [Actions](#actions)
+  - [Shortcode](#shortcode)
+  - [Contribute](#contribute)
+  - [Unit testing](#unit-testing)
+  - [Code Snippets](#code-snippets)
+  - [Minimum Requirements](#minimum-requirements)
+  - [License](#license)
+  - [BTW, We're Hiring!](#btw-were-hiring)
 
 ## Overview
 
@@ -131,6 +133,9 @@ unit tests.
 
 You should have PHP CLI > 7.1 installed. If you have Xdebug enabled with php, code coverage report will be
 generated at `/tmp/report/html`
+
+## Code Snippets
+Code snippets to extend and customize the plugin can be found [here](docs/CODE_SNIPPETS.md).
 
 ## Minimum Requirements
 

--- a/docs/CODE_SNIPPETS.md
+++ b/docs/CODE_SNIPPETS.md
@@ -1,0 +1,19 @@
+# Code Snippets
+> Code snippets to customize and extend the pluign.
+
+1. **Assign different user role to user created by the plugin**
+```php
+add_action( 'rtcamp.google_user_created', function( $user_id ) {
+   // Get WP_User object from user_id.
+   $user = get_user( $user_id );
+
+   // Get the default role set under Settings -> General.
+   $default_role = get_option( 'default_role' );
+
+   // Remove default assigned role.
+   $user->remove_role( $default_role );
+
+   // Assign different role.
+   $user->add_role( 'editor' );
+} );
+```

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,9 @@ Once you're ready to send a pull request, please run through the following check
 
 - Run `composer install && composer tests:unit` to run unit tests.
 
+= Code Snippets =
+Code snippets to extend and customize the plugin can be found [here](https://github.com/rtCamp/login-with-google/blob/develop/docs/CODE_SNIPPETS.md).
+
 == Screenshots ==
 
 1. Login screen with Google option added.


### PR DESCRIPTION
## Description
This PR creates a `docs/CODE_SNIPPETS.md` file to include the code snippets. It also adds code snippets to `Assign a different user role to the user created by the plugin`.