### PR TITLE
#260 Do not use extract() in template display, use $variables directly instead

### DIFF
--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -41,12 +41,6 @@ class Helper {
 			return '';
 		}
 
-		if ( ! empty( $variables ) ) {
-			// This will needed for provide variables to the template.
-			// Will skips those variables, those already defined.
-			extract( $variables, EXTR_SKIP ); // phpcs:ignore
-		}
-
 		if ( true === $should_echo ) {
 
 			// Load template and output the data.

--- a/templates/google-login-button.php
+++ b/templates/google-login-button.php
@@ -4,21 +4,22 @@
  *
  * @package RtCamp\GithubLogin
  * @since 1.0.0
+ * @var array<string, string> $variables
  */
 
 use RtCamp\GoogleLogin\Utils\Helper;
 
-if ( isset( $custom_btn_text ) && $custom_btn_text ) {
-	$button_text = esc_html( $custom_btn_text );
+if (!empty($variables['custom_btn_text'])) {
+	$button_text = esc_html($variables['custom_btn_text']);
 } else {
-	$button_text = ( ! empty( $button_text ) ) ? $button_text : __( 'Login with Google', 'login-with-google' );
+	$button_text = $variables['button_text'] ?? __( 'Login with Google', 'login-with-google' );
 }
 
-if ( empty( $login_url ) ) {
+if (empty($variables['login_url'])) {
 	return;
 }
 
-$button_url = $login_url;
+$button_url = $variables['login_url'];
 
 if ( is_user_logged_in() ) {
 	$button_text  = __( 'Log out', 'login-with-google' );


### PR DESCRIPTION
Template file:
* line 7, phpdoc comment: defined `$variables` as an associative array (builtin `include()` infers context, so parent's `$variables` is visible here).
* line 12: `isset($x) && $x` can be always shortened as `!empty($x)` + actually used parent context's `$variables` to access what we need
* lines 18 and 22: ditto

Also, since `extract` is now unnecessary, I've removed it from the `Helper` class.

Fixes: #260 