### PR TITLE
[Fix] Migrate `rtcamp.google_redirect_url` hook from Action to Filter

### DIFF
--- a/src/Modules/Login.php
+++ b/src/Modules/Login.php
@@ -83,10 +83,11 @@ class Login implements ModuleInterface {
 		// Priority is 20 because of issue: https://core.trac.wordpress.org/ticket/46748.
 		add_action( 'authenticate', [ $this, 'authenticate' ], 20 );
 		add_action( 'rtcamp.google_register_user', [ $this->authenticator, 'register' ] );
-		add_action( 'rtcamp.google_redirect_url', [ $this, 'redirect_url' ] );
 		add_action( 'rtcamp.google_user_created', [ $this, 'user_meta' ] );
 		add_filter( 'rtcamp.google_login_state', [ $this, 'state_redirect' ] );
 		add_action( 'wp_login', [ $this, 'login_redirect' ] );
+
+		add_filter( 'rtcamp.google_redirect_url', [ $this, 'redirect_url' ] );
 	}
 
 	/**


### PR DESCRIPTION
## Description
- `rtcamp.google_redirect_url` is a filter and was used as a hook in `src/Modules/Login.php`. This PR updates the `add_action` function to `add_filter`.
- Not updating `redirect_url` function as it already returns a value as a filter should.

https://github.com/rtCamp/login-with-google/blob/01400d99a27628aa348cae6b570138b14f603fe1/src/Modules/Login.php#L188-L191