### PR TITLE
Added warning message on one-tap for 2FA

### DIFF
--- a/src/Modules/Settings.php
+++ b/src/Modules/Settings.php
@@ -216,7 +216,7 @@ class Settings implements ModuleInterface {
 															value='1'>
 			<?php esc_html_e( 'Create a new user account if it does not exist already', 'login-with-google' ); ?>
 		</label>
-		<p class="description">
+		<p class="<?php echo esc_attr( 'error-message' ); ?>">
 			<?php
 			echo wp_kses_post(
 				sprintf(
@@ -244,7 +244,7 @@ class Settings implements ModuleInterface {
 					value='1'>
 			<?php esc_html_e( 'One Tap Login', 'login-with-google' ); ?>
 		</label>
-		<p>
+		<p class="<?php echo esc_attr( 'error-message' ); ?>">
 			<?php esc_html_e( 'Warning: One Tap login is more convenient, but it bypasses two-factor authentication (2FA).', 'login-with-google' ); ?>
 		</p>
 		<?php


### PR DESCRIPTION
### Description

- This PR adds a warning message next to the One Tap login setting in the plugin’s settings page. The warning informs users that while One Tap login offers convenience, it bypasses two-factor authentication (2FA), so users should enable it with caution.

# Fixes
[Two different login process when two factor authentication plugin is used (#238)](https://github.com/rtCamp/login-with-google/issues/238)