### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpcs_on_pull_request.yml
+++ b/.github/workflows/phpcs_on_pull_request.yml
@@ -4,6 +4,9 @@ jobs:
   runPHPCSInspection:
     name: Run PHPCS inspection
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/login-with-google/security/code-scanning/15](https://github.com/rtCamp/login-with-google/security/code-scanning/15)

In general, the problem is fixed by explicitly specifying `permissions:` for the workflow or for the specific job, instead of relying on the repository/organization default `GITHUB_TOKEN` permissions. This enforces the principle of least privilege and satisfies CodeQL’s requirement that permissions be explicitly limited.

For this workflow, the best fix without changing existing functionality is to add a `permissions:` block at the job level for `runPHPCSInspection`. Since the job runs a code review action that may need to interact with pull requests, we can conservatively grant `contents: read` (to read the code) and `pull-requests: write` (to allow the action to comment/review on the PR if it uses `GITHUB_TOKEN`). If the action in reality does not need write access, `pull-requests: write` could later be removed, but adding it now minimizes the risk of breaking existing behavior. The change should be inserted under the job definition (after `runs-on: ubuntu-latest` or before, both are valid YAML) in `.github/workflows/phpcs_on_pull_request.yml`. No imports or additional files are needed, since this is purely a workflow YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
