### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release_plugin_on_tag.yml
+++ b/.github/workflows/release_plugin_on_tag.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v6
     - name: Set up PHP


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/login-with-google/security/code-scanning/16](https://github.com/rtCamp/login-with-google/security/code-scanning/16)

In general, to fix this problem, add an explicit `permissions:` block either at the top level of the workflow (to apply to all jobs) or within the `release` job to restrict the default `GITHUB_TOKEN` permissions to only what’s required. Since this workflow only has a single job, adding `permissions:` under `jobs.release` is sufficient and makes the job’s requirements explicit.

For this specific workflow, the steps suggest the following needs:
- `actions/checkout` and read access to repository contents: `contents: read`
- `softprops/action-gh-release` creates or updates a GitHub Release and uploads assets, which requires write access to repository contents/releases: `contents: write`

No other GitHub write scopes (issues, pull-requests, etc.) are obviously required. Therefore, the best minimal change is to add a `permissions:` block under `jobs.release` that grants `contents: write`. This automatically includes read, satisfying both `checkout` and the release action. The change should be inserted directly under `runs-on: ubuntu-latest` (line 8) in `.github/workflows/release_plugin_on_tag.yml`. No imports or additional definitions are needed since this is purely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
