### PR TITLE
Fix/general cleanup

### DIFF
--- a/src/Modules/Block.php
+++ b/src/Modules/Block.php
@@ -140,9 +140,9 @@ class Block implements Module {
 		) {
 			$markup = $this->markup(
 				[
-					'login_url'           => $this->client->authorization_url(),
-					'custom_btn_text'     => $attributes['buttonText'] ?? false,
-					'force_display_block' => $attributes['forceDisplay'] ?? false,
+					'login_url'       => $this->client->authorization_url(),
+					'custom_btn_text' => $attributes['buttonText'] ?? '',
+					'force_display'   => $force_display,
 				]
 			);
 
@@ -174,7 +174,7 @@ class Block implements Module {
 			[
 				'login_url'       => '#',
 				'custom_btn_text' => '',
-				'forceDisplay'    => false,
+				'force_display'   => false,
 			]
 		);
 

--- a/src/Modules/Shortcode.php
+++ b/src/Modules/Shortcode.php
@@ -95,12 +95,10 @@ class Shortcode implements ModuleInterface {
 	 * @return string
 	 */
 	public function callback( $attrs = [] ): string {
-		$redirect_to = Helper::get_redirect_url();
-		$attrs       = shortcode_atts(
+		$attrs = shortcode_atts(
 			[
-				'button_text'   => __( 'Login with google', 'login-with-google' ),
+				'button_text'   => '',
 				'force_display' => 'no',
-				'redirect_to'   => $redirect_to,
 			],
 			$attrs,
 			self::TAG

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -41,12 +41,6 @@ class Helper {
 			return '';
 		}
 
-		if ( ! empty( $variables ) ) {
-			// This will needed for provide variables to the template.
-			// Will skips those variables, those already defined.
-			extract( $variables, EXTR_SKIP ); // phpcs:ignore
-		}
-
 		if ( true === $should_echo ) {
 
 			// Load template and output the data.

--- a/src/Utils/TokenVerifier.php
+++ b/src/Utils/TokenVerifier.php
@@ -75,13 +75,11 @@ class TokenVerifier {
 	 * @param string $algo Algorithm.
 	 */
 	public static function get_supported_algorithm( string $algo = '' ) {
-		$find_algo = array_key_exists( $algo, self::SUPPORTED_ALGORITHMS );
-
-		if ( ! $find_algo ) {
-			return apply_filters( 'rtcamp.default_algorithm', OPENSSL_ALGO_SHA256, $algo );
+		if ( isset( self::SUPPORTED_ALGORITHMS[ $algo ] ) ) {
+			return self::SUPPORTED_ALGORITHMS[ $algo ];
 		}
 
-		return self::SUPPORTED_ALGORITHMS[ $algo ];
+		return apply_filters( 'rtcamp.default_algorithm', OPENSSL_ALGO_SHA256, $algo );
 	}
 
 	/**

--- a/src/Utils/TokenVerifier.php
+++ b/src/Utils/TokenVerifier.php
@@ -119,7 +119,7 @@ class TokenVerifier {
 	}
 
 	/**
-	 * Base64 URL Encode a string.
+	 * Base64 URL Decode a string.
 	 *
 	 * @param string $str Input string to decode.
 	 *

--- a/templates/google-login-button.php
+++ b/templates/google-login-button.php
@@ -8,6 +8,11 @@
 
 use RtCamp\GoogleLogin\Utils\Helper;
 
+// Variables for rendering the template.
+$login_url = $variables['login_url'] ?? null;
+$button_text = $variables['button_text'] ?? null;
+$custom_btn_text = $variables['custom_btn_text'] ?? null;
+
 if ( isset( $custom_btn_text ) && $custom_btn_text ) {
 	$button_text = esc_html( $custom_btn_text );
 } else {

--- a/templates/google-login-button.php
+++ b/templates/google-login-button.php
@@ -2,7 +2,7 @@
 /**
  * Template for google login button.
  *
- * @package RtCamp\GithubLogin
+ * @package RtCamp\GoogleLogin
  * @since 1.0.0
  */
 

--- a/templates/google-login-button.php
+++ b/templates/google-login-button.php
@@ -9,35 +9,30 @@
 use RtCamp\GoogleLogin\Utils\Helper;
 
 // Variables for rendering the template.
-$login_url = $variables['login_url'] ?? null;
-$button_text = $variables['button_text'] ?? null;
+$login_url       = $variables['login_url'] ?? null;
+$button_text     = $variables['button_text'] ?? null;
 $custom_btn_text = $variables['custom_btn_text'] ?? null;
-
-if ( isset( $custom_btn_text ) && $custom_btn_text ) {
-	$button_text = esc_html( $custom_btn_text );
-} else {
-	$button_text = ( ! empty( $button_text ) ) ? $button_text : __( 'Login with Google', 'login-with-google' );
-}
 
 if ( empty( $login_url ) ) {
 	return;
 }
 
-$button_url = $login_url;
-
 if ( is_user_logged_in() ) {
-	$button_text  = __( 'Log out', 'login-with-google' );
-	$redirect_url = Helper::get_redirect_url();
-	$button_url   = wp_logout_url( $redirect_url );
+	$button_text = __( 'Log out', 'login-with-google' );
+	$button_url  = wp_logout_url( Helper::get_redirect_url() );
+} else {
+	$button_url = $login_url;
+
+	if ( ! empty( $custom_btn_text ) ) {
+		$button_text = $custom_btn_text;
+	} elseif ( empty( $button_text ) ) {
+		$button_text = __( 'Login with Google', 'login-with-google' );
+	}
 }
 ?>
 <div class="wp_google_login">
 	<div class="wp_google_login__button-container">
-		<a class="wp_google_login__button"
-			<?php
-			printf( ' href="%s"', esc_url( $button_url ) );
-			?>
-		>
+		<a class="wp_google_login__button" href="<?php echo esc_url( $button_url ); ?>">
 			<span class="wp_google_login__google-icon"></span>
 			<?php echo esc_html( $button_text ); ?>
 		</a>

--- a/tests/php/PrivateAccess.php
+++ b/tests/php/PrivateAccess.php
@@ -87,6 +87,6 @@ trait PrivateAccess {
 	 */
 	protected function get_static_private_property( $class, $property_name ) {
 		$properties = ( new ReflectionClass( $class ) )->getStaticProperties();
-		return array_key_exists( $property_name, $properties ) ? $properties[ $property_name ] : null;
+		return $properties[ $property_name ] ?? null;
 	}
 }

--- a/tests/php/Unit/Modules/ShortCodeTest.php
+++ b/tests/php/Unit/Modules/ShortCodeTest.php
@@ -103,7 +103,7 @@ class ShortCodeTest extends TestCase {
 			[
 				'args'       => [
 					[
-						'button_text'   => __( 'Login with google', 'login-with-google' ),
+						'button_text'   => '',
 						'force_display' => 'no',
 						'redirect_to'   => 'https://example.com/',
 					],
@@ -137,7 +137,7 @@ class ShortCodeTest extends TestCase {
 			[
 				'args'       => [
 					[
-						'button_text'   => __( 'Login with google', 'login-with-google' ),
+						'button_text'   => '',
 						'force_display' => 'no',
 						'redirect_to'   => null,
 					],
@@ -184,7 +184,7 @@ class ShortCodeTest extends TestCase {
 			[
 				'/some/path/templates/google-login-button.php',
 				[
-					'button_text'   => 'Login with google',
+					'button_text'   => '',
 					'force_display' => 'no',
 					'redirect_to'   => null,
 					'login_url'     => 'https://google.com/auth/',

--- a/tests/php/Unit/Utils/GoogleClientTest.php
+++ b/tests/php/Unit/Utils/GoogleClientTest.php
@@ -68,7 +68,7 @@ class GoogleClientTest extends TestCase {
 	 * @covers ::gt_redirect_url
 	 */
 	public function testCallWithOtherMethods() {
-		WP_Mock::expectFilterNotAdded( 'rtcamp.github_redirect_url', '' );
+		WP_Mock::expectFilterNotAdded( 'rtcamp.google_redirect_url', '' );
 		$this->testee->__call( 'some_other_method', null );
 
 		$this->assertConditionsMet();


### PR DESCRIPTION
Hi rtCamp team,

I was looking at this plugin for a lightweight Google login option. A quick review highlighted a few issues such as extract(), template variable naming and some leftover mentions of the 'github login' plugin that this plugin sourced.

In reviewing similar PRs, it looks like someone else was concerned about extract(). The benefit of this new PR is that it aligns with WordPress Coding standards, but please do credit them for their work.

Fixes #260
Fixes #267

Summary:

- template cleanup
- fix Block's `forceDisplay` and `force_display_block` template parameter mismatch
- fix some documentation typos
- fix filter hookname in test
- avoid `extract()` and `array_key_exists()`