### PR TITLE
fix: Filter hooks should use add_filter() methods

### DIFF
--- a/src/Modules/Login.php
+++ b/src/Modules/Login.php
@@ -83,16 +83,16 @@ class Login implements ModuleInterface {
 		 * Actions.
 		 */
 		add_action( 'login_form', [ $this, 'login_button' ] );
-		// Priority is 20 because of issue: https://core.trac.wordpress.org/ticket/46748.
-		add_action( 'authenticate', [ $this, 'authenticate' ], 20 );
-		add_action( 'rtcamp.google_register_user', [ $this->authenticator, 'register' ] );
 		add_action( 'rtcamp.google_user_created', [ $this, 'user_meta' ] );
 		add_action( 'wp_login', [ $this, 'login_redirect' ] );
 
 		/**
 		 * Filters.
 		 */
+		// Priority is 20 because of issue: https://core.trac.wordpress.org/ticket/46748.
+		add_filter( 'authenticate', [ $this, 'authenticate' ], 20 );
 		add_filter( 'rtcamp.google_redirect_url', [ $this, 'redirect_url' ] );
+		add_filter( 'rtcamp.google_register_user', [ $this->authenticator, 'register' ] );
 		add_filter( 'rtcamp.google_login_state', [ $this, 'state_redirect' ] );
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -111,7 +111,7 @@ class Plugin {
 
 		add_action( 'init', [ $this, 'load_translations' ] );
 
-		add_action( 'plugin_action_links_' . plugin_basename( $this->path ) . '/login-with-google.php', [ $this, 'add_plugin_action_links' ] );
+		add_filter( 'plugin_action_links_' . plugin_basename( $this->path ) . '/login-with-google.php', [ $this, 'add_plugin_action_links' ] );
 	}
 
 	/**

--- a/tests/php/Unit/Modules/LoginTest.php
+++ b/tests/php/Unit/Modules/LoginTest.php
@@ -74,12 +74,12 @@ class LoginTest extends TestCase {
 	 */
 	public function testInit() {
 		WP_Mock::expectActionAdded( 'login_form', [ $this->testee, 'login_button' ] );
-		WP_Mock::expectActionAdded( 'authenticate', [ $this->testee, 'authenticate' ], 20 );
-		WP_Mock::expectActionAdded( 'rtcamp.google_register_user', [ $this->authenticatorMock, 'register' ] );
-		WP_Mock::expectActionAdded( 'rtcamp.google_redirect_url', [ $this->testee, 'redirect_url' ] );
 		WP_Mock::expectActionAdded( 'rtcamp.google_user_created', [ $this->testee, 'user_meta' ] );
-		WP_Mock::expectFilterAdded( 'rtcamp.google_login_state', [ $this->testee, 'state_redirect' ] );
 		WP_Mock::expectActionAdded( 'wp_login', [ $this->testee, 'login_redirect' ] );
+		WP_Mock::expectFilterAdded( 'authenticate', [ $this->testee, 'authenticate' ], 20 );
+		WP_Mock::expectFilterAdded( 'rtcamp.google_redirect_url', [ $this->testee, 'redirect_url' ] );
+		WP_Mock::expectFilterAdded( 'rtcamp.google_register_user', [ $this->authenticatorMock, 'register' ] );
+		WP_Mock::expectFilterAdded( 'rtcamp.google_login_state', [ $this->testee, 'state_redirect' ] );
 
 		$this->testee->init();
 		$this->assertConditionsMet();

--- a/tests/php/Unit/PluginTest.php
+++ b/tests/php/Unit/PluginTest.php
@@ -287,7 +287,7 @@ class PluginTest extends TestCase {
 		);
 
 		WP_Mock::expectActionAdded( 'init', [ $this->testee, 'load_translations' ] );
-		WP_Mock::expectActionAdded( 'plugin_action_links_' . plugin_basename( $this->testee->path ) . '/login-with-google.php', [ $this->testee, 'add_plugin_action_links' ] );
+		WP_Mock::expectFilterAdded( 'plugin_action_links_' . plugin_basename( $this->testee->path ) . '/login-with-google.php', [ $this->testee, 'add_plugin_action_links' ] );
 		WP_Mock::expectFilter( 'rtcamp.google_login_modules', $this->testee->active_modules );
 
 		$this->testee->run();


### PR DESCRIPTION
Internally, add_action() and add_filter() are registered in the same hooks registry. However, the semantic differences are notable.

From [Actions vs. Filters](https://developer.wordpress.org/plugins/hooks/#actions-vs-filters):

> The main difference between an action and a filter can be summed up like this:
> 
>  - an action takes the info it receives, does something with it, and returns nothing. In other words: it acts on something and then exits, returning nothing back to the calling hook.
>  - a filter takes the info it receives, modifies it somehow, and returns it. In other words: it filters something and passes it back to the hook for further use.

So we would expect functions and methods which return `void` to be "actions". Conversely, "filters" are expected to return a value that is compatible with the first argument.