### PR TITLE
Override yauzl to use patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12417,16 +12417,6 @@
 				"bser": "2.1.1"
 			}
 		},
-		"node_modules/fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pend": "~1.2.0"
-			}
-		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -25568,14 +25558,17 @@
 			}
 		},
 		"node_modules/yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+			"integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
+				"pend": "~1.2.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"webpack-dev-server": "^5.2.3",
 		"minimatch": ">=10.2.1",
 		"bn.js": ">=5.2.3",
-		"serialize-javascript": "^7.0.3"
+		"serialize-javascript": "^7.0.3",
+		"yauzl": "^3.2.1"
 	},
 	"devDependencies": {
 		"@wordpress/scripts": "^31.6.0",


### PR DESCRIPTION
## Description

Update yauzl to use patched version.

## Technical Details

Since the yauzl is dependent on WP Scripts, it is necessary to override the version and use the patched version.