### PR TITLE
fix: use add_filter() for plugin_action_links hook

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -111,7 +111,7 @@ class Plugin {
 
 		add_action( 'init', [ $this, 'load_translations' ] );
 
-		add_action( 'plugin_action_links_' . plugin_basename( $this->path ) . '/login-with-google.php', [ $this, 'add_plugin_action_links' ] );
+		add_filter( 'plugin_action_links_' . plugin_basename( $this->path ) . '/login-with-google.php', [ $this, 'add_plugin_action_links' ] );
 	}
 
 	/**


### PR DESCRIPTION
## What

`plugin_action_links_{$plugin}` is a filter, not an action — callbacks
must return the modified `$links` array. The hook in `Plugin::run()` was
registered with `add_action()`, which silently discards the return value
of `add_plugin_action_links()`, so the Settings link was never injected
into the Plugins list table.

**Before:**
```php
add_action( 'plugin_action_links_' . plugin_basename( $this->path ) . '/login-with-google.php', [ $this, 'add_plugin_action_links' ] );
```

**After:**
```php
add_filter( 'plugin_action_links_' . plugin_basename( $this->path ) . '/login-with-google.php', [ $this, 'add_plugin_action_links' ] );
```

## Why `add_filter()`?

`add_action()` passes `null` as the first argument to the callback and
ignores the return value. `add_filter()` passes the existing `$links` array
and uses the returned value to replace it — which is exactly what
`add_plugin_action_links()` relies on when calling `array_merge()`.

## Testing

1. Install the plugin on a fresh WordPress site.
2. Go to **Plugins → Installed Plugins**.
3. Confirm a **Settings** link appears under "Login With Google."

Closes #331

---
*Development and testing assisted by AI. All code reviewed and verified manually.*