### PR TITLE
fix(deps): security bumps for 5 Dependabot alerts

### DIFF
--- a/.github/workflows/release_plugin_on_tag.yml
+++ b/.github/workflows/release_plugin_on_tag.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up PHP
-      uses: shivammathur/setup-php@2.32.0
+      uses: shivammathur/setup-php@2.37.1
       with:
         php-version: '7.4'
         coverage: xdebug

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"lodash": "^4.18.1",
 				"sass": "^1.98.0",
 				"sass-loader": "^16.0.7",
-				"webpack-dev-server": "^5.2.3"
+				"webpack-dev-server": "^5.2.5"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -13919,9 +13919,9 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-			"integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+			"integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -25108,9 +25108,9 @@
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-			"integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+			"integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
 		"lint:js:fix": "npm run lint:js -- --fix ./assets/src/blocks"
 	},
 	"overrides": {
-		"webpack-dev-server": "^5.2.3",
+		"webpack-dev-server": "^5.2.5",
 		"minimatch": ">=10.2.1",
 		"bn.js": ">=5.2.3",
 		"serialize-javascript": "^7.0.3",
-		"yauzl": "^3.2.1"
+		"yauzl": "^3.2.1",
+		"http-proxy-middleware": "^2.0.10"
 	},
 	"devDependencies": {
 		"@wordpress/scripts": "^31.6.0",
@@ -26,6 +27,6 @@
 		"lodash": "^4.18.1",
 		"sass": "^1.98.0",
 		"sass-loader": "^16.0.7",
-		"webpack-dev-server": "^5.2.3"
+		"webpack-dev-server": "^5.2.5"
 	}
 }


### PR DESCRIPTION
## Summary
Resolves all 5 open Dependabot security alerts (5 moderate) via lockfile-only npm bumps and a same-major GitHub Actions pin bump. No application source changes.

| Package | Old → New | Alert | Severity | GHSA / CVE |
|---|---|---|---|---|
| http-proxy-middleware (npm, transitive) | 2.0.9 → 2.0.10 | #255 | moderate | GHSA-64mm-vxmg-q3vj / CVE-2026-55602 |
| webpack-dev-server (npm, dev) | 5.2.3 → 5.2.5 | #253 | moderate | GHSA-mx8g-39q3-5c79 / CVE-2026-9595 |
| webpack-dev-server (npm, dev) | 5.2.3 → 5.2.5 | #235 | moderate | GHSA-79cf-xcqc-c78w / CVE-2026-6402 |
| shivammathur/setup-php (actions) | 2.32.0 → 2.37.1 | #237 | moderate | GHSA-5wxr-w449-57cm |
| shivammathur/setup-php (actions) | 2.32.0 → 2.37.1 | #236 | moderate | GHSA-pqwm-q9pv-ph8r / CVE-2026-46420 |

No CRITICAL alerts.

## Why
- **http-proxy-middleware / webpack-dev-server**: patched releases in the same major. `webpack-dev-server` bumped on the devDependency and existing override (`^5.2.5`); `http-proxy-middleware` (transitive) pinned to `^2.0.10` via overrides to force the patched build.
- **shivammathur/setup-php**: workflow pin `2.32.0` → `2.37.1`, the standard same-major (v2) action fix per the advisories.

## How tested
Lockfile-only (`npm install --package-lock-only --ignore-scripts`); not built locally. Resolved versions verified in `package-lock.json` (http-proxy-middleware 2.0.10, webpack-dev-server 5.2.5). Please verify in CI.

## Residual risk
None flagged. All five fixes are same-major and the packages were present at vulnerable versions. No major bumps, no not-applicable items.