### PR TITLE
Add filter for Google auth error redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ via [wp-cli](https://developer.wordpress.org/cli/commands/config/).
 | `rtcamp.google_login_state` | Filters the state to pass to the Google API. | <ul><li>`state_data` - contains the default state data.</li></ul>
 | `rtcamp.default_algorithm` | Filters default algorithm for openssl signature verification | <ul><li>`default_algo` - Default algorithm.</li><li>`algo` - Algorithm from JWT header.</li></ul>
 | `rtcamp.google_redirect_url` | Filters the URL to which the user will be redirected post successful authentication | <ul><li> `redirect_uri` - contains the URL to be redirected to. Defaults to the current URL.</li></ul>
+| `rtcamp.google_login_failed_redirect` | Filters the URL to redirect the user to when Google authentication fails. Return a non-empty URL to redirect the user to a custom error page instead of showing the default login error. | <ul><li>`redirect_to` - Redirect URL. Default empty string (no redirect).</li><li>`error` - `WP_Error` object describing the authentication failure.</li></ul>
 
 #### Actions
 

--- a/src/Modules/Login.php
+++ b/src/Modules/Login.php
@@ -183,8 +183,12 @@ class Login implements ModuleInterface {
 			$redirect_to = apply_filters( 'rtcamp.google_login_failed_redirect', '', $error );
 
 			if ( is_string( $redirect_to ) && '' !== $redirect_to ) {
-				wp_safe_redirect( $redirect_to, 302, 'Login with Google' );
-				exit;
+				$redirect_to = wp_validate_redirect( $redirect_to, '' );
+
+				if ( '' !== $redirect_to ) {
+					wp_safe_redirect( $redirect_to, 302, 'Login with Google' );
+					exit;
+				}
 			}
 
 			return $error;

--- a/src/Modules/Login.php
+++ b/src/Modules/Login.php
@@ -166,7 +166,28 @@ class Login implements ModuleInterface {
 			throw new Exception( __( 'Could not authenticate the user, please try again.', 'login-with-google' ) );
 
 		} catch ( Throwable $e ) {
-			return new WP_Error( 'google_login_failed', $e->getMessage() );
+			$error = new WP_Error( 'google_login_failed', $e->getMessage() );
+
+			/**
+			 * Filter the URL to redirect the user to when Google authentication fails.
+			 *
+			 * By default an empty string is returned and WordPress renders the
+			 * default login error. Return a non-empty URL to redirect the user to
+			 * a custom page (e.g. a friendly error page) instead.
+			 *
+			 * @since 1.4.4
+			 *
+			 * @param string   $redirect_to Redirect URL. Default empty string (no redirect).
+			 * @param WP_Error $error       Error object describing the authentication failure.
+			 */
+			$redirect_to = apply_filters( 'rtcamp.google_login_failed_redirect', '', $error );
+
+			if ( is_string( $redirect_to ) && '' !== $redirect_to ) {
+				wp_safe_redirect( $redirect_to, 302, 'Login with Google' );
+				exit;
+			}
+
+			return $error;
 		}
 	}
 

--- a/tests/php/Unit/Modules/LoginTest.php
+++ b/tests/php/Unit/Modules/LoginTest.php
@@ -393,6 +393,12 @@ class LoginTest extends TestCase {
 		       ->withAnyArgs()
 		       ->reply( 'https://example.com/custom-error' );
 
+		// The redirect target is validated before use; return it unchanged.
+		WP_Mock::userFunction( 'wp_validate_redirect' )
+		       ->once()
+		       ->with( 'https://example.com/custom-error', '' )
+		       ->andReturn( 'https://example.com/custom-error' );
+
 		// wp_safe_redirect() is followed by exit; throw to simulate the halt.
 		WP_Mock::userFunction( 'wp_safe_redirect' )
 		       ->once()

--- a/tests/php/Unit/Modules/LoginTest.php
+++ b/tests/php/Unit/Modules/LoginTest.php
@@ -349,6 +349,63 @@ class LoginTest extends TestCase {
 	}
 
 	/**
+	 * When the failure-redirect filter returns a URL, the user should be
+	 * redirected there instead of receiving the default WP_Error.
+	 *
+	 * @covers ::authenticate
+	 */
+	public function testAuthenticationExceptionRedirectsWhenFilterReturnsUrl() {
+		$helperMock = Mockery::mock( 'alias:' . Helper::class );
+		$helperMock->expects( 'filter_input' )->once()->withArgs(
+			[
+				INPUT_GET,
+				'code',
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
+			]
+		)->andReturn( 'abc' );
+
+		$helperMock->expects( 'filter_input' )->once()->withArgs(
+			[
+				INPUT_GET,
+				'state',
+				FILTER_SANITIZE_FULL_SPECIAL_CHARS
+			]
+		)->andReturn( 'eyJwcm92aWRlciI6Imdvb2dsZSIsIm5vbmNlIjoidGVzdG5vbmNlIn0=' );
+
+		$this->wpMockFunction(
+			'wp_verify_nonce',
+			[
+				'testnonce',
+				'login_with_google',
+			],
+			1,
+			true
+		);
+
+		$this->ghClientMock->expects( $this->once() )
+		                   ->method( 'set_access_token' )
+		                   ->with( 'abc' )
+		                   ->willThrowException( new Exception( 'Exception for test' ) );
+
+		Mockery::mock( 'WP_Error' );
+
+		WP_Mock::onFilter( 'rtcamp.google_login_failed_redirect' )
+		       ->withAnyArgs()
+		       ->reply( 'https://example.com/custom-error' );
+
+		// wp_safe_redirect() is followed by exit; throw to simulate the halt.
+		WP_Mock::userFunction( 'wp_safe_redirect' )
+		       ->once()
+		       ->with( 'https://example.com/custom-error', 302, 'Login with Google' )
+		       ->andThrow( new Exception( 'redirect-exit' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'redirect-exit' );
+
+		$this->testee->authenticate();
+	}
+
+	/**
 	 * @covers ::user_meta
 	 */
 	public function testUserMeta() {


### PR DESCRIPTION
## What & why

Adds a filter, `rtcamp.google_login_failed_redirect`, so sites can control where a user lands when Google authentication fails. Currently `Login::authenticate()` hardcodes a `WP_Error` return on failure (`src/Modules/Login.php`), and WordPress re-renders `wp-login.php` with that error — there is no way to send the user to a custom/friendly error page.

Closes #173

## Approach

In the `catch ( Throwable $e )` block, after building the `WP_Error`, apply a new filter passing the default (`''`) and the `WP_Error`. If a consumer returns a non-empty string, it is run through `wp_validate_redirect()` (empty fallback); only when a validated URL survives do we `wp_safe_redirect()` there and `exit`. Otherwise the original `WP_Error` is returned. Fully backward-compatible — default behavior is unchanged, and invalid/off-site filter values fall through to the default error rather than silently redirecting to `wp-admin`.

```php
add_filter( 'rtcamp.google_login_failed_redirect', function ( $redirect_to, $error ) {
    return home_url( '/login-error/' );
}, 10, 2 );
```

## Testing

Run the added unit test and the module suite:

```bash
composer install
./vendor/bin/phpunit --filter testAuthenticationExceptionRedirectsWhenFilterReturnsUrl tests/php/Unit/Modules/LoginTest.php
./vendor/bin/phpunit tests/php/Unit/Modules/LoginTest.php
composer cs -- src/Modules/Login.php tests/php/Unit/Modules/LoginTest.php
```

- [x] New test `testAuthenticationExceptionRedirectsWhenFilterReturnsUrl` passes (PHP 8.3 and 8.5)
- [x] `phpcs` clean on changed files
- [x] Default path unchanged — `WP_Error` still returned when no filter is set (`testAuthenticationCapturesExceptions` still green)
- [x] Invalid/off-site filter value falls through to `WP_Error` instead of redirecting (via `wp_validate_redirect`)
- [x] New filter documented in `README.md`
- [ ] Reviewer: confirm redirect fires end-to-end on a real failed Google login with a registered filter

> Note: the pre-existing `testInit` failure (and the wider suite's Mockery `alias:` cross-contamination errors) exist on `develop` independent of this change — this PR does not touch `init()`.
